### PR TITLE
updated typescript-fetch client mustache to add default security conf…

### DIFF
--- a/modules/swagger-codegen/src/main/resources/typescript-fetch-httpclient/api.mustache
+++ b/modules/swagger-codegen/src/main/resources/typescript-fetch-httpclient/api.mustache
@@ -16,6 +16,8 @@ export interface FetchAPI { (url: string, init?: any): Promise<any>; }
 
 const BASE_PATH = "{{{basePath}}}".replace(/\/+$/, "");
 
+const DEFAULT_CONFIG = new Configuration();
+
 /**
 * Used HTTP client.
 */
@@ -31,7 +33,7 @@ export class BaseAPI {
     fetch: FetchAPI;
     public configuration: Configuration;
 
-    constructor(fetch: FetchAPI = httpClient.fetch, basePath: string = BASE_PATH, configuration: Configuration = new Configuration()) {
+    constructor(fetch: FetchAPI = httpClient.fetch, basePath: string = BASE_PATH, configuration: Configuration = DEFAULT_CONFIG) {
         this.basePath = basePath;
         this.fetch = fetch;
         this.configuration = configuration;
@@ -229,7 +231,8 @@ export class {{classname}} extends BaseAPI {
      {{/allParams}}
      */
     {{nickname}}({{#hasParams}}params: { {{#allParams}} "{{paramName}}"{{^required}}?{{/required}}: {{{dataType}}};{{/allParams}} }, {{/hasParams}}options: any = {}) {
-        return {{classname}}Fp.{{nickname}}({{#hasParams}}params, {{/hasParams}}{{#hasAuthMethods}}this.configuration, {{/hasAuthMethods}}options)(this.fetch, this.basePath);
+        {{#hasAuthMethods}}const config = this.configuration || DEFAULT_CONFIG;
+        {{/hasAuthMethods}}return {{classname}}Fp.{{nickname}}({{#hasParams}}params, {{/hasParams}}{{#hasAuthMethods}}config, {{/hasAuthMethods}}options)(this.fetch, this.basePath);
     }
 {{/operation}}
 };
@@ -238,7 +241,7 @@ export class {{classname}} extends BaseAPI {
  * {{classname}} - factory interface{{#description}}
  * {{&description}}{{/description}}
  */
-export const {{classname}}Factory = function (fetch: FetchAPI, basePath?: string) {
+export const {{classname}}Factory = function (fetch: FetchAPI, basePath?: string, defaultConfig?: Configuration) {
     return {
 {{#operation}}
         /**
@@ -251,7 +254,8 @@ export const {{classname}}Factory = function (fetch: FetchAPI, basePath?: string
          {{/allParams}}
          */
         {{nickname}}({{#hasParams}}params: { {{#allParams}} "{{paramName}}"{{^required}}?{{/required}}: {{{dataType}}};{{/allParams}} }, {{/hasParams}}{{#hasAuthMethods}}configuration: Configuration, {{/hasAuthMethods}}options: any = {}) {
-            return {{classname}}Fp.{{nickname}}({{#hasParams}}params, {{/hasParams}}{{#hasAuthMethods}}configuration, {{/hasAuthMethods}}options)(fetch, basePath);
+            {{#hasAuthMethods}}const config = configuration || defaultConfig || DEFAULT_CONFIG;
+            {{/hasAuthMethods}}return {{classname}}Fp.{{nickname}}({{#hasParams}}params, {{/hasParams}}{{#hasAuthMethods}}config, {{/hasAuthMethods}}options)(fetch, basePath);
         },
 {{/operation}}
     };


### PR DESCRIPTION
…iguration

### PR checklist

- [ ] Read the [contribution guidelines](https://github.com/swagger-api/swagger-codegen/blob/master/CONTRIBUTING.md).
- [ ] Ran the shell script under `./bin/` to update Petstore sample so that CIs can verify the change. (For instance, only need to run `./bin/{LANG}-petstore.sh` and `./bin/security/{LANG}-petstore.sh` if updating the {LANG} (e.g. php, ruby, python, etc) code generator or {LANG} client's mustache templates). Windows batch files can be found in `.\bin\windows\`.
- [ ] Filed the PR against the correct branch: `3.0.0` branch for changes related to OpenAPI spec 3.0. Default: `master`.
- [ ] Copied the [technical committee](https://github.com/swagger-api/swagger-codegen/#swagger-codegen-technical-committee) to review the pull request if your PR is targeting a particular programming langauge.

### Description of the PR

(details of the change, additional tests that have been done, reference to the issue for tracking, etc)

